### PR TITLE
fix: upgrade @modelcontextprotocol/sdk to v1.17.2 for critical transport handling fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "zod": "^3.25.50"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.17.2",
     "next": ">=13.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

Upgrades `@modelcontextprotocol/sdk` peer dependency to v1.17.2 to incorporate a critical bug fix for transport handling in multi-client scenarios.

## Problem

The previous SDK version (^1.12.0) contained a bug where the Protocol class would overwrite its internal transport reference when handling concurrent requests from multiple clients. This caused responses to be incorrectly routed to the wrong client connection.

This issue particularly affected production deployments using StreamableHTTP transport where multiple clients connect to the same server instance.

# Solution

The SDK v1.17.2 includes the fix from [modelcontextprotocol/typescript-sdk#820](https://github.com/modelcontextprotocol/typescript-sdk/pull/820) which ensures proper transport context isolation by capturing the transport reference at request time through closure.

## Compatibility

✅ **No breaking changes affecting mcp-adapter**
- All existing tests pass with v1.17.2
- The v1.14.0 breaking change (reject → decline) doesn't affect this codebase
- New features between v1.12.0 and v1.17.2 are mostly additive (DNS rebinding protection, OIDC support, enhanced type safety)

## Impact

- ✅ Fixes response routing in multi-client scenarios
- ✅ Prevents cross-client data leakage
- ✅ Ensures reliable message delivery in production environments
- ✅ All existing tests continue to pass
- ✅ Backward compatible with existing implementations

## Testing

```bash
pnpm test
# All 19 tests pass ✓
```

- Existing unit tests continue to pass
- Multi-client scenarios now correctly route responses to originating clients
- Compatible with all current Next.js versions (>=13.0.0)

Related Issues

- Upstream fix: modelcontextprotocol/typescript-sdk#820
- SDK releases: https://github.com/modelcontextprotocol/typescript-sdk/releases