### PR TITLE
chore: update examples

### DIFF
--- a/examples/auth/route.ts
+++ b/examples/auth/route.ts
@@ -1,4 +1,4 @@
-import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import {
   createMcpHandler,
   experimental_withMcpAuth as withMcpAuth,
@@ -8,11 +8,14 @@ import { z } from "zod";
 // Define the handler with proper parameter validation
 const handler = createMcpHandler(
   (server) => {
-    server.tool(
+    server.registerTool(
       "echo",
-      "Echo a message back with authentication info",
       {
-        message: z.string().describe("The message to echo back"),
+        title: "Echo a message back with authentication info",
+        description: "Echo a message back with authentication info",
+        inputSchema: {
+          message: z.string().describe("The message to echo back"),
+        },
       },
       async ({ message }, extra) => {
         return {

--- a/examples/route.ts
+++ b/examples/route.ts
@@ -1,8 +1,11 @@
-import createMcpRouteHandler from '../dist/next/index';
+import { createMcpHandler } from '../dist/index';
 
-const handler = createMcpRouteHandler(
+const handler = createMcpHandler(
   server => {
-    server.tool('echo', 'Echo a message', {}, async () => {
+    server.registerTool('echo', {
+      title: 'Echo a message',
+      description: 'Echo a message',
+    }, async () => {
       return {
         content: [
           {
@@ -17,7 +20,7 @@ const handler = createMcpRouteHandler(
   {
     capabilities: {},
   },
-  // Optional: Comes from the createMcpRouteHandler config
+  // Optional: Comes from the createMcpHandler config
   {
     streamableHttpEndpoint: '/mcp',
     sseEndpoint: '/sse',


### PR DESCRIPTION
Fixes the non-auth example and uses the new `registerTool()` method instead of `tool()`
